### PR TITLE
Update linenumber highlight

### DIFF
--- a/themes/light-table.css
+++ b/themes/light-table.css
@@ -57,7 +57,8 @@
 	color: #99997a;
 	padding-left: 15px;
 }
-.cm-s-light-table.CodeMirror .CodeMirror-activeline{
+.cm-s-light-table.CodeMirror .CodeMirror-activeline,
+.cm-s-light-table.CodeMirror.CodeMirror-focused .CodeMirror-activeline .CodeMirror-gutter-elt{
 	background: rgba(255,255,255,.1);
 }
 .cm-s-light-table.CodeMirror pre{


### PR DESCRIPTION
Hi,
Brackets sprint 30 introduced a default background color for linenumber highlighting that needs to be overriden, here's the patch for that.
