### PR TITLE
Remove old theme class on CodeMirror when switching themes

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,6 +54,7 @@ define(function (require, exports, module) {
 		return theme.charAt(0).toUpperCase() + theme.slice(1);
 	};
 	Themes.load = function (theme) {
+		$("#editor-holder .CodeMirror").removeClass("cm-s-" + Themes.currentTheme);
 		Themes.setCommand(Themes.currentTheme, false);
 		if (theme) {
 			Themes.currentTheme = theme;


### PR DESCRIPTION
Removes the previous cm-s-(theme) class from CodeMirror when switching themes.  This fixes a problem with the syntax highlighting on my Minimap extension.
