### PR TITLE
Disappearing cursor fix

### DIFF
--- a/themes/peacock.css
+++ b/themes/peacock.css
@@ -41,8 +41,8 @@ CodeMirror CSS: Paweł Chętkowski
 .CodeMirror-selected{background:rgba(255,255,255,0.1) !important;} /*Selected lines - may need !important*/
 .CodeMirror-gutter-elt{background:#2b2a27 !important;}
 .CodeMirror-activeline-background{background:rgba(255,255,255,0.1) !important;} /*Active line - may need !important*/
-.CodeMirror .CodeMirror-matchingtag{background:none !important; text-decoration: none; border-bottom: 1px solid #FF5D38;} /*Matching tags, open/close. Try !important for bg, color etc. if it doesn't work*/
-div.CodeMirror span.CodeMirror-matchingbracket{background:#403c37 !important;} /*Matching brackets, open/close*/
+.CodeMirror .CodeMirror-matchingtag{background:none; text-decoration: none; border-bottom: 1px solid #FF5D38;} /*Matching tags, open/close. Try !important for bg, color etc. if it doesn't work*/
+div.CodeMirror span.CodeMirror-matchingbracket{background:none; text-decoration: none; border-bottom: 1px solid #FF5D38;} /*Matching brackets, open/close*/
 
 
     /*Status bar - bottom*/


### PR DESCRIPTION
In sprint 38 there is a problem with cursor; if theme is using background property for highlighting matching tags/brackets (it's a CM issue). Adjusted theme by switching to underline.
