### PR TITLE
night-sky theme, dark title bar

### DIFF
--- a/themes/night-sky.css
+++ b/themes/night-sky.css
@@ -6,6 +6,21 @@
 #main-toolbar{
 	background-color:#3c3f41;
 }
+#titlebar{
+	background:#3c3f41;
+	color:rgba(255,255,255,0.9);
+}
+#titlebar .nav .dropdown .dropdown-toggle{
+	color:rgba(255,255,255,0.9);
+}
+#titlebar .nav .dropdown .dropdown-toggle:hover {
+	background: #fff;
+	border-color: #fff;
+	color: #000;
+}
+#titlebar .nav .dropdown.open .dropdown-toggle{
+	color: #000;
+}
 #status-bar{
     background:#3c3f41;
 	color:rgba(255,255,255,0.9);


### PR DESCRIPTION
night-sky had a white titlebar (kind of like the Solarized Dark screenshot at https://raw.githubusercontent.com/Jacse/themes-for-brackets/master/images/solarized-dark.png).

Added some CSS rules to match the darkness (the popup menus are still white)
