### PR TITLE
Removed fixed font for the theme

### DIFF
--- a/themes/peacock.css
+++ b/themes/peacock.css
@@ -7,7 +7,6 @@ CodeMirror CSS: Paweł Chętkowski
 .CodeMirror, .CodeMirror-scroll{
     background:#2b2a27;
     color:#ede0ce;
-    font-size: 14px;
 }/*Main coding area, without line count.*/
 
 .CodeMirror div.CodeMirror-cursor {border-left: 1px solid #ede0ce !important;}


### PR DESCRIPTION
Fixed font was preventing Bracket's font size setting from working properly.
